### PR TITLE
Patch the starting scenario from Project RimFactory Revived

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -31,6 +31,7 @@
     <li IfModActive="oskarpotocki.vfe.tribals">Mods and Shit/VFE Tribals</li>
     <li IfModActive="adamas.plantgenetics">Mods and Shit/Plant Genetics</li>
     <li IfModActive="VanillaExpanded.VPlantsESucculents">Mods and Shit/VPE Succulents</li>
+    <li IfModActive="spdskatr.projectrimfactory">Mods and Shit/Project RimFactory Revived</li>
     <!-- <li IfModActive="oskarpotocki.vfe.medieval2">Mods and Shit/VFE Medieval 2</li> -->
   </v1.5>
 </loadFolders>

--- a/Mods and Shit/Project RimFactory Revived/Patches/project rimfactory revived patch.xml
+++ b/Mods and Shit/Project RimFactory Revived/Patches/project rimfactory revived patch.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/ScenarioDef[defName="PRF_FactoryEntrepreneur"]/scenario/parts/li[project="Devilstrand"]</xpath>
+  </Operation>
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/ScenarioDef[defName="PRF_FactoryEntrepreneur"]/scenario/parts/li[project="TreeSowing"]</xpath>
+  </Operation>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ScenarioDef[defName="PRF_FactoryEntrepreneur"]/scenario/parts</xpath>
+    <value>
+      <li Class="ScenPart_StartingThing_Defined">
+        <def>StartingThing_Defined</def>
+        <thingDef>Plant_Rice_SeedBundle</thingDef>
+      </li>
+      <li Class="ScenPart_StartingThing_Defined">
+        <def>StartingThing_Defined</def>
+        <thingDef>Plant_Potato_SeedBundle</thingDef>
+      </li>
+      <li Class="ScenPart_StartingThing_Defined">
+        <def>StartingThing_Defined</def>
+        <thingDef>Plant_Healroot_SeedBundle</thingDef>
+      </li>
+      <li Class="ScenPart_StartingThing_Defined">
+        <def>StartingThing_Defined</def>
+        <thingDef>Plant_Cotton_SeedBundle</thingDef>
+      </li>
+      <li Class="ScenPart_StartingThing_Defined">
+        <def>StartingThing_Defined</def>
+        <thingDef>Plant_Psychoid_SeedBundle</thingDef>
+      </li>
+      <li Class="ScenPart_StartingThing_Defined">
+        <def>StartingThing_Defined</def>
+        <thingDef>Plant_Devilstrand_SeedBundle</thingDef>
+      </li>
+    </value>
+  </Operation>
+</Patch>


### PR DESCRIPTION
It's not part of the modpack, but we may as well stop the Progression mods from breaking things any time we can.

- Removes starting research of Tree Sowing
- Removes starting research of Devilstrand
- Adds seed packets to starting things:
  - Rice 
  - Potato
  - Healroot
  - Cotton
  - Psychoid
  - Devilstrand