### PR TITLE
Patch starting scenario for Ancient Hydroponic Farm Facilities

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -32,6 +32,7 @@
     <li IfModActive="adamas.plantgenetics">Mods and Shit/Plant Genetics</li>
     <li IfModActive="VanillaExpanded.VPlantsESucculents">Mods and Shit/VPE Succulents</li>
     <li IfModActive="spdskatr.projectrimfactory">Mods and Shit/Project RimFactory Revived</li>
+    <li IfModActive="xmb.ancienthydroponicfarmfacilities.mo">Mods and Shit/Ancient Hydroponic Farm Facilities</li>
     <!-- <li IfModActive="oskarpotocki.vfe.medieval2">Mods and Shit/VFE Medieval 2</li> -->
   </v1.5>
 </loadFolders>

--- a/Mods and Shit/Ancient Hydroponic Farm Facilities/Patches/ancient hydroponic farm facilities.xml
+++ b/Mods and Shit/Ancient Hydroponic Farm Facilities/Patches/ancient hydroponic farm facilities.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/ScenarioDef[defName="AncientFarm"]/scenario/parts/li[project="Devilstrand"]</xpath>
+  </Operation>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ScenarioDef[defName="AncientFarm"]/scenario/parts</xpath>
+    <value>
+      <li Class="ScenPart_StartingThing_Defined">
+        <def>StartingThing_Defined</def>
+        <thingDef>Plant_Rice_SeedBundle</thingDef>
+      </li>
+      <li Class="ScenPart_StartingThing_Defined">
+        <def>StartingThing_Defined</def>
+        <thingDef>Plant_Potato_SeedBundle</thingDef>
+      </li>
+      <li Class="ScenPart_StartingThing_Defined">
+        <def>StartingThing_Defined</def>
+        <thingDef>Plant_Healroot_SeedBundle</thingDef>
+      </li>
+      <li Class="ScenPart_StartingThing_Defined">
+        <def>StartingThing_Defined</def>
+        <thingDef>Plant_Cotton_SeedBundle</thingDef>
+      </li>
+      <li Class="ScenPart_StartingThing_Defined">
+        <def>StartingThing_Defined</def>
+        <thingDef>Plant_Psychoid_SeedBundle</thingDef>
+      </li>
+      <li Class="ScenPart_StartingThing_Defined">
+        <def>StartingThing_Defined</def>
+        <thingDef>Plant_Devilstrand_SeedBundle</thingDef>
+      </li>
+    </value>
+  </Operation>
+</Patch>


### PR DESCRIPTION
### Mod Behavior Customization:

* `Mods and Shit/Ancient Hydroponic Farm Facilities/Patches/ancient hydroponic farm facilities.xml`: 
  - Removed the "Devilstrand" project from the "AncientFarm" scenario.  
  - Added a set of starting seed bundles (e.g., rice, potatoes, healroot, cotton, psychoid, and devilstrand) to the "AncientFarm" scenario,.