### PR TITLE
Clean up def removals

### DIFF
--- a/Mods and Shit/Medieval Overhaul/Patches/medieval overhaul patch.xml
+++ b/Mods and Shit/Medieval Overhaul/Patches/medieval overhaul patch.xml
@@ -98,6 +98,30 @@
 
 
                         <!-- FUCK THESE RESEARCH PROJECTS -->
+
+      <Operation Class="PatchOperationAdd">
+        <xpath>/Defs</xpath>
+        <value>
+            <ReplaceLib.ReplacerDef>
+                <defName>Ferny_PA_MO_Compat</defName>
+                    <replacers>
+                        <li>
+                            <replace>DankPyon_IntermediateAgriculture</replace>
+                            <with>DankPyon_BasicAgriculture</with>
+                        </li>
+                        <li>
+                            <replace>DankPyon_AdvancedAgriculture</replace>
+                            <with>DankPyon_BasicAgriculture</with>
+                        </li>
+                        <li>
+                            <replace>DankPyon_TreeGriffonBerry</replace>
+                            <with>DankPyon_BasicAgriculture</with>
+                        </li>
+                   </replacers>
+            </ReplaceLib.ReplacerDef>
+        </value>
+	  </Operation>
+      
       <Operation Class="PatchOperationRemove">
           <success>Always</success>
           <xpath>Defs/ResearchProjectDef[defName="DankPyon_IntermediateAgriculture"]</xpath>

--- a/Mods and Shit/Regrowth Core/Patches/regrowth core patch.xml
+++ b/Mods and Shit/Regrowth Core/Patches/regrowth core patch.xml
@@ -1,5 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
+      <Operation Class="PatchOperationAdd">
+        <xpath>/Defs</xpath>
+        <value>
+            <ReplaceLib.ReplacerDef>
+                <defName>Ferny_PA_ReGrowth_Compat</defName>
+                    <replacers>
+                        <li>
+                            <replace>RG_BerryCultivation</replace>
+                            <with></with>
+                        </li>
+                        <li>
+                            <replace>RG_MushroomCultivation</replace>
+                            <with></with>
+                        </li>
+                   </replacers>
+            </ReplaceLib.ReplacerDef>
+        </value>
+	  </Operation>
+    
       <Operation Class="PatchOperationRemove">
           <success>Always</success>
           <xpath>Defs/ResearchProjectDef[defName="RG_BerryCultivation"]</xpath>

--- a/Mods and Shit/VFE Tribals/Patches/vfe tribals patch.xml
+++ b/Mods and Shit/VFE Tribals/Patches/vfe tribals patch.xml
@@ -1,5 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
+    <!-- Replace VE researches before removing their defs -->
+      <Operation Class="PatchOperationAdd">
+            <xpath>/Defs</xpath>
+            <value>
+                <ReplaceLib.ReplacerDef>
+                    <defName>Ferny_PA_VFET_Compat</defName>
+                        <replacers>
+                            <li>
+                                <replace>VFET_Cultivation</replace>
+                                <with>VFET_Agriculture</with>
+                            </li>
+                            <li>
+                                <replace>VFET_Medicine</replace>
+                                <with>VFET_Agriculture</with>
+                            </li>
+                       </replacers>
+                </ReplaceLib.ReplacerDef>
+            </value>
+	   </Operation>
+
       <Operation Class="PatchOperationRemove">
           <success>Always</success>
           <xpath>Defs/VFETribals.TribalResearchProjectDef[defName="VFET_Cultivation"]</xpath>
@@ -8,11 +28,20 @@
           <success>Always</success>
           <xpath>Defs/VFETribals.TribalResearchProjectDef[defName="VFET_Medicine"]</xpath>
       </Operation>
+
+      <!-- Center Agriculture so it doesn't look ugly as a prereq to Culture -->
+      <Operation Class="PatchOperationReplace">
+          <xpath>Defs/VFETribals.TribalResearchProjectDef[defName="VFET_Agriculture"]/researchViewX</xpath>
+          <value>
+              <researchViewX>2.00</researchViewX>
+          </value>
+      </Operation>
       <Operation Class="PatchOperationReplace">
           <success>Always</success>
           <xpath>Defs/VFETribals.TribalResearchProjectDef[defName="VFET_Culture"]/prerequisites</xpath>
           <value>
             <prerequisites>
+                <li>VFET_Agriculture</li>
                 <li>VFET_Tribalwear</li>
                 <li>VFET_Furniture</li>
                 <li>VFET_AnimalHandling</li>

--- a/Mods and Shit/VPE Succulents/Patches/vpe succulents patch.xml
+++ b/Mods and Shit/VPE Succulents/Patches/vpe succulents patch.xml
@@ -1,5 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
+
+      <Operation Class="PatchOperationAdd">
+        <xpath>/Defs</xpath>
+        <value>
+            <ReplaceLib.ReplacerDef>
+                <defName>Ferny_PA_VFE_Succ_Compat</defName>
+                    <replacers>
+                        <li>
+                            <replace>VCE_SucculentSowing</replace>
+                            <with></with>
+                        </li>
+                    </replacers>
+            </ReplaceLib.ReplacerDef>
+        </value>
+	  </Operation>
+
       <Operation Class="PatchOperationRemove">
           <success>Always</success>
           <xpath>Defs/ResearchProjectDef[defName="VCE_SucculentSowing"]</xpath>


### PR DESCRIPTION
# Note
Tested with prog ag and the mods affected (added Research Reinvented: Stepping Stones as well), not the whole pack.  Don't expect this to be an issue, but calling it out in case you want me to

# Changes

* For all mods that have defs removed, made sure that they have the prereq moved to a more appropriate tech, or to no def
    * This should fix any other mods that require researches from these mods
* Made VFE Tribals Agricultural a prereq for culture, didn't make sense that all techs were a prereq except this
    * shifted it over one position so it lined up with the other techs and the lines between techs didn't look as ugly

# Testing

* Added all mods without VE Tribals and noted what researches existed and what they unlocked
* Added in Prog Ag and repeated
* All expected researched were missing, Agriculture was shifter and set as a prereq to culture, all items and orders were tied to the correct research