### PR TITLE
1.5 DesignationCategory value orphaned after Defs/DesignationCategory deletion

### DIFF
--- a/1.5/Defs/ThingDefs_Buildings.xml
+++ b/1.5/Defs/ThingDefs_Buildings.xml
@@ -35,7 +35,7 @@
             <Flammability>1.0</Flammability>
             <Cleanliness>-2</Cleanliness>
         </statBases>
-        <designationCategory>Ferny_Farming</designationCategory>
+        <designationCategory>Production</designationCategory>
         <uiOrder>2520</uiOrder>
         <passability>PassThroughOnly</passability>
         <pathCost>50</pathCost>
@@ -87,7 +87,7 @@
         <scatterableOnMapGen>false</scatterableOnMapGen>
         <useHitPoints>false</useHitPoints>
         <size>(1,1)</size>
-        <designationCategory>Ferny_Farming</designationCategory>
+        <designationCategory>Production</designationCategory>
         <uiOrder>2001</uiOrder>
         <passability>Standable</passability>
         <hasInteractionCell>True</hasInteractionCell>

--- a/1.5/Patches/core patch.xml
+++ b/1.5/Patches/core patch.xml
@@ -23,7 +23,7 @@
         <success>Always</success>
         <xpath>Defs/ThingDef[defName="HydroponicsBasin"]/designationCategory</xpath>
         <value>
-            <designationCategory>Ferny_Farming</designationCategory>
+            <designationCategory>Production</designationCategory>
         </value>
     </Operation>
 

--- a/Mods and Shit/Biomes Core/Patches/biomes core patch.xml
+++ b/Mods and Shit/Biomes Core/Patches/biomes core patch.xml
@@ -4,7 +4,7 @@
           <success>Always</success>
           <xpath>Defs/TerrainDef[@Name="BiomesCore_FloatingGarden"]/designationCategory</xpath>
           <value>
-              <designationCategory>Ferny_Farming</designationCategory>
+              <designationCategory>Production</designationCategory>
           </value>
       </Operation>
 </Patch>


### PR DESCRIPTION
_Seed Packing Spot_, _Seed Packing Workbench_ and the _Hydroponic basin_ c**annot be built due to an orphaned architect Def remaining in the 1.5 files - the last commit only swapped the 1.6 values.** Doing the same for 1.5 restores the buildings. 