### PR TITLE
Add patches for scenarios from 10 mods and Odyssey DLC

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -75,5 +75,16 @@
     <li IfModActive="vanillaexpanded.vfecore">Mods and Shit/VE Furniture</li>
     <li IfModActive="sarg.alphabiomes">Mods and Shit/Alpha Biomes</li>
     <li IfModActive="Erin.HotDrink">Mods and Shit/Erins Hot Drink</li>
+    <li IfModActive="Ludeon.RimWorld.Odyssey">Mods and Shit/Odyssey</li>
+    <li IfModActive="RedMattis.BetterPrerequisites">Mods and Shit/BigAndSmall Framework</li>
+    <li IfModActive="XMB.AncientUrbanrUins.MO">Mods and Shit/Ancient Urban Ruins</li>
+    <li IfModActive="onyxae.dragonsdescent">Mods and Shit/Dragons Descent</li>
+    <li IfModActive="VexedTrees980.RimGnoblinsBiotech">Mods and Shit/Rim-Gnoblins</li>
+    <li IfModActive="Rimsenal.Spacer">Mods and Shit/Rimsenal Spacer</li>
+    <li IfModActive="wvc.sergkart.races.biotech">Mods and Shit/WVC XenotypesAndGenes</li>
+    <li IfModActive="Hautarche.HautsTraits">Mods and Shit/Hauts Added Traits</li>
+    <li IfModActive="GoGaTio.NewAnomalyThreats">Mods and Shit/New Anomaly Threats</li>
+    <li IfModActive="RedMattis.BigSmall">Mods and Shit/BigAndSmall Races</li>
+    <li IfModActive="RedMattis.LamiasAndOtherSnakes">Mods and Shit/BigAndSmall Snakes</li>
   </v1.6>
 </loadFolders>

--- a/Mods and Shit/Ancient Urban Ruins/Patches/ancienturbanruins patch.xml
+++ b/Mods and Shit/Ancient Urban Ruins/Patches/ancienturbanruins patch.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+<!-- Safe House was omitted: description says "lack essential survival resources" -->
+<!-- Scavenger Group -->
+    <Operation Class="PatchOperationAdd">
+        <success>Always</success>
+        <xpath>Defs/ScenarioDef[defName="AM_ScavengerGroup"]/scenario/parts</xpath>
+        <value>
+        <li Class="RandomVegetables.ScenPart_RandomSeedBundles">
+            <_itemCount>1</_itemCount>
+            <def>RandomSeedBundles</def>
+        </li>
+        <li Class="ProgressionAgriculture.ScenPart_StartingSeeds">
+            <def>Ferny_StartingSeeds</def>
+            <thingDef>Plant_Psychoid_SeedBundle</thingDef>
+        </li>
+        </value>
+    </Operation>
+</Patch>

--- a/Mods and Shit/BigAndSmall Framework/Patches/bas framework patch.xml
+++ b/Mods and Shit/BigAndSmall Framework/Patches/bas framework patch.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+<!-- Crashlanded on Alien Planet -->
+    <Operation Class="PatchOperationAdd">
+        <success>Always</success>
+        <xpath>Defs/ScenarioDef[defName="BS_CrashlandedXenoPlus"]/scenario/parts</xpath>
+        <value>
+        <li Class="RandomVegetables.ScenPart_RandomSeedBundles">
+            <_itemCount>2</_itemCount>
+            <def>RandomSeedBundles</def>
+        </li>
+        <li Class="ProgressionAgriculture.ScenPart_StartingSeeds">
+            <def>Ferny_StartingSeeds</def>
+            <thingDef>Plant_Healroot_SeedBundle</thingDef>
+        </li>
+        <li Class="ProgressionAgriculture.ScenPart_StartingSeeds">
+            <def>Ferny_StartingSeeds</def>
+            <thingDef>Plant_Cotton_SeedBundle</thingDef>
+        </li>
+        <li Class="ProgressionAgriculture.ScenPart_StartingSeeds">
+            <def>Ferny_StartingSeeds</def>
+            <thingDef>Plant_Psychoid_SeedBundle</thingDef>
+        </li>
+        </value>
+    </Operation>
+</Patch>

--- a/Mods and Shit/BigAndSmall Races/Patches/bas races patch.xml
+++ b/Mods and Shit/BigAndSmall Races/Patches/bas races patch.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+    <!-- Exiled Jotun Adventurer -->
+    <Operation Class="PatchOperationAdd">
+        <success>Always</success>
+        <xpath>Defs/ScenarioDef[defName="BS_Exiled_Jotun_Adventurer"]/scenario/parts</xpath>
+        <value>
+            <li Class="RandomVegetables.ScenPart_RandomSeedBundles">
+                <_itemCount>3</_itemCount>
+                <def>RandomSeedBundles</def>
+            </li>
+            <li Class="ProgressionAgriculture.ScenPart_StartingSeeds">
+                <def>Ferny_StartingSeeds</def>
+                <thingDef>Plant_Healroot_SeedBundle</thingDef>
+            </li>
+            <li Class="ProgressionAgriculture.ScenPart_StartingSeeds">
+                <def>Ferny_StartingSeeds</def>
+                <thingDef>Plant_Cotton_SeedBundle</thingDef>
+            </li>
+        </value>
+    </Operation>
+</Patch>

--- a/Mods and Shit/BigAndSmall Snakes/Patches/bas snakes patch.xml
+++ b/Mods and Shit/BigAndSmall Snakes/Patches/bas snakes patch.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+    <!-- Viper Family Escort -->
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>Royalty</li>
+        </mods>
+        <match Class="PatchOperationSequence">
+            <operations>
+                <li Class="PatchOperationAdd">
+                    <success>Always</success>
+                    <xpath>Defs/ScenarioDef[defName="LoS_ViperScenario"]/scenario/parts</xpath>
+                    <value>
+                        <li Class="RandomVegetables.ScenPart_RandomSeedBundles">
+                            <_itemCount>2</_itemCount>
+                            <def>RandomSeedBundles</def>
+                        </li>
+                        <li Class="ProgressionAgriculture.ScenPart_StartingSeeds">
+                            <def>Ferny_StartingSeeds</def>
+                            <thingDef>Plant_Healroot_SeedBundle</thingDef>
+                        </li>
+                        <li Class="ProgressionAgriculture.ScenPart_StartingSeeds">
+                            <def>Ferny_StartingSeeds</def>
+                            <thingDef>Plant_Cotton_SeedBundle</thingDef>
+                        </li>
+                        <li Class="ProgressionAgriculture.ScenPart_StartingSeeds">
+                            <def>Ferny_StartingSeeds</def>
+                            <thingDef>Plant_Psychoid_SeedBundle</thingDef>
+                        </li>
+                    </value>
+                </li>
+            </operations>
+        </match>
+    </Operation>
+
+    <!-- Failed Tiamat -->
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>Alpha Genes</li>
+        </mods>
+        <match Class="PatchOperationSequence">
+            <operations>
+                <li Class="PatchOperationAdd">
+                    <success>Always</success>
+                    <xpath>Defs/ScenarioDef[defName="LOS_TiamatScenario"]/scenario/parts</xpath>
+                    <value>
+                        <li Class="RandomVegetables.ScenPart_RandomSeedBundles">
+                            <_itemCount>2</_itemCount>
+                            <def>RandomSeedBundles</def>
+                        </li>
+                    </value>
+                </li>
+            </operations>
+        </match>
+    </Operation>
+</Patch>

--- a/Mods and Shit/Dragons Descent/Patches/dragonsdescent patch.xml
+++ b/Mods and Shit/Dragons Descent/Patches/dragonsdescent patch.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+<!-- Dragon Thieves -->
+    <Operation Class="PatchOperationAdd">
+        <success>Always</success>
+        <xpath>Defs/ScenarioDef[defName="DragonThieves"]/scenario/parts</xpath>
+        <value>
+        <li Class="RandomVegetables.ScenPart_RandomSeedBundles">
+            <_itemCount>2</_itemCount>
+            <def>RandomSeedBundles</def>
+        </li>
+        <li Class="ProgressionAgriculture.ScenPart_StartingSeeds">
+            <def>Ferny_StartingSeeds</def>
+            <thingDef>Plant_Healroot_SeedBundle</thingDef>
+        </li>
+        <li Class="ProgressionAgriculture.ScenPart_StartingSeeds">
+            <def>Ferny_StartingSeeds</def>
+            <thingDef>Plant_Cotton_SeedBundle</thingDef>
+        </li>
+        <li Class="ProgressionAgriculture.ScenPart_StartingSeeds">
+            <def>Ferny_StartingSeeds</def>
+            <thingDef>Plant_Psychoid_SeedBundle</thingDef>
+        </li>
+        </value>
+    </Operation>
+</Patch>

--- a/Mods and Shit/Hauts Added Traits/Patches/hautsaddedtraits patch.xml
+++ b/Mods and Shit/Hauts Added Traits/Patches/hautsaddedtraits patch.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+    <!-- Latent Psychic Runaways -->
+
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>Royalty</li>
+        </mods>
+        <match Class="PatchOperationSequence">
+            <operations>
+                <li Class="PatchOperationAdd">
+                    <success>Always</success>
+                    <xpath>Defs/ScenarioDef[defName="HVT_LatentPsychics"]/scenario/parts</xpath>
+                    <value>
+                        <li Class="RandomVegetables.ScenPart_RandomSeedBundles">
+                            <_itemCount>2</_itemCount>
+                            <def>RandomSeedBundles</def>
+                        </li>
+                    </value>
+                </li>
+                <li Class="PatchOperationAdd">
+                    <success>Always</success>
+                    <xpath>Defs/ScenarioDef[defName="HVT_LatentPsychicsTribal"]/scenario/parts</xpath>
+                    <value>
+                        <li Class="RandomVegetables.ScenPart_RandomSeedBundles">
+                            <_itemCount>2</_itemCount>
+                            <def>RandomSeedBundles</def>
+                        </li>
+                    </value>
+                </li>
+            </operations>
+        </match>
+    </Operation>
+</Patch>

--- a/Mods and Shit/New Anomaly Threats/Patches/newanomalythreats patch.xml
+++ b/Mods and Shit/New Anomaly Threats/Patches/newanomalythreats patch.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+    <!-- The Gravship -->
+    <Operation Class="PatchOperationAdd">
+        <success>Always</success>
+        <xpath>Defs/ScenarioDef[defName="NAT_Cultists"]/scenario/parts</xpath>
+        <value>
+            <li Class="RandomVegetables.ScenPart_RandomSeedBundles">
+                <_itemCount>2</_itemCount>
+                <def>RandomSeedBundles</def>
+            </li>
+            <li Class="ProgressionAgriculture.ScenPart_StartingSeeds">
+                <def>Ferny_StartingSeeds</def>
+                <thingDef>Plant_Healroot_SeedBundle</thingDef>
+            </li>
+            <li Class="ProgressionAgriculture.ScenPart_StartingSeeds">
+                <def>Ferny_StartingSeeds</def>
+                <thingDef>Plant_Cotton_SeedBundle</thingDef>
+            </li>
+            <li Class="ProgressionAgriculture.ScenPart_StartingSeeds">
+                <def>Ferny_StartingSeeds</def>
+                <thingDef>Plant_Psychoid_SeedBundle</thingDef>
+            </li>
+        </value>
+    </Operation>
+</Patch>

--- a/Mods and Shit/Odyssey/Patches/odyssey patch.xml
+++ b/Mods and Shit/Odyssey/Patches/odyssey patch.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+    <!-- The Gravship -->
+    <Operation Class="PatchOperationAdd">
+        <success>Always</success>
+        <xpath>Defs/ScenarioDef[defName="TheGravship"]/scenario/parts</xpath>
+        <value>
+            <li Class="RandomVegetables.ScenPart_RandomSeedBundles">
+                <_itemCount>2</_itemCount>
+                <def>RandomSeedBundles</def>
+            </li>
+            <li Class="ProgressionAgriculture.ScenPart_StartingSeeds">
+                <def>Ferny_StartingSeeds</def>
+                <thingDef>Plant_Healroot_SeedBundle</thingDef>
+            </li>
+            <li Class="ProgressionAgriculture.ScenPart_StartingSeeds">
+                <def>Ferny_StartingSeeds</def>
+                <thingDef>Plant_Cotton_SeedBundle</thingDef>
+            </li>
+            <li Class="ProgressionAgriculture.ScenPart_StartingSeeds">
+                <def>Ferny_StartingSeeds</def>
+                <thingDef>Plant_Psychoid_SeedBundle</thingDef>
+            </li>
+        </value>
+    </Operation>
+</Patch>

--- a/Mods and Shit/Rim-Gnoblins/Patches/rimgnoblins patch.xml
+++ b/Mods and Shit/Rim-Gnoblins/Patches/rimgnoblins patch.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+    <!-- A New Warren -->
+    <Operation Class="PatchOperationAdd">
+        <success>Always</success>
+        <xpath>Defs/ScenarioDef[defName="LostGnoblins"]/scenario/parts</xpath>
+        <value>
+            <li Class="RandomVegetables.ScenPart_RandomSeedBundles">
+                <_itemCount>2</_itemCount>
+                <def>RandomSeedBundles</def>
+            </li>
+            <li Class="ProgressionAgriculture.ScenPart_StartingSeeds">
+                <def>Ferny_StartingSeeds</def>
+                <thingDef>Plant_Healroot_SeedBundle</thingDef>
+            </li>
+        </value>
+    </Operation>
+</Patch>

--- a/Mods and Shit/Rimsenal Spacer/Patches/rimsenalspacer patch.xml
+++ b/Mods and Shit/Rimsenal Spacer/Patches/rimsenalspacer patch.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+    <!-- Planetfall -->
+    <Operation Class="PatchOperationAdd">
+        <success>Always</success>
+        <xpath>Defs/ScenarioDef[defName="RSPlanetfall"]/scenario/parts</xpath>
+        <value>
+            <li Class="RandomVegetables.ScenPart_RandomSeedBundles">
+                <_itemCount>4</_itemCount>
+                <def>RandomSeedBundles</def>
+            </li>
+            <li Class="ProgressionAgriculture.ScenPart_StartingSeeds">
+                <def>Ferny_StartingSeeds</def>
+                <thingDef>Plant_Healroot_SeedBundle</thingDef>
+            </li>
+            <li Class="ProgressionAgriculture.ScenPart_StartingSeeds">
+                <def>Ferny_StartingSeeds</def>
+                <thingDef>Plant_Cotton_SeedBundle</thingDef>
+            </li>
+            <li Class="ProgressionAgriculture.ScenPart_StartingSeeds">
+                <def>Ferny_StartingSeeds</def>
+                <thingDef>Plant_Psychoid_SeedBundle</thingDef>
+            </li>
+        </value>
+    </Operation>
+</Patch>

--- a/Mods and Shit/WVC XenotypesAndGenes/Patches/wvcxag patch.xml
+++ b/Mods and Shit/WVC XenotypesAndGenes/Patches/wvcxag patch.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+    <!-- Long Running Joke, Raised from the Dead, With All Eyes, From the Void: omitted -->
+    <!-- Tribal Mechanitor -->
+    <Operation Class="PatchOperationAdd">
+        <success>Always</success>
+        <xpath>Defs/ScenarioDef[defName="WVC_XenotypesAndGenes_RuneDryad"]/scenario/parts</xpath>
+        <value>
+            <li Class="RandomVegetables.ScenPart_RandomSeedBundles">
+                <_itemCount>2</_itemCount>
+                <def>RandomSeedBundles</def>
+            </li>
+        </value>
+    </Operation>
+</Patch>


### PR DESCRIPTION
Add patches for scenarios from:

- Ancinent Urban Ruins
- Big and Small - Framework
- Big and Small - Races
- Big and Small - Lamias and other Snake-People
- Dragons Descent
- Hauts' Added Traits
- New Anomaly Threats
- Odyssey
- Rim-Gnoblins
- Rimsenal Faction Pack - Spacer
- WVC - Xenotypes and Genes